### PR TITLE
feat: infer substance for unit-only dose entries

### DIFF
--- a/qslang/load.py
+++ b/qslang/load.py
@@ -5,7 +5,7 @@ import json
 import logging
 import os
 import re
-from collections import defaultdict
+from collections import Counter, defaultdict
 from datetime import datetime
 from pathlib import Path
 from typing import Literal
@@ -70,6 +70,7 @@ def load_events(
         events += new_events
 
     events = _extend_substance_abbrs(events)
+    events = _infer_implicit_substances(events)
     events = _tag_substances(events)
     events = sorted(events)
     events = filter_events(events, start, end, substances)
@@ -319,6 +320,98 @@ def _extend_substance_abbrs(events) -> list[Event]:
     for e in events:
         if e.substance and e.substance.lower() in substance_aliases_inv:
             e.data["substance"] = substance_aliases_inv[e.substance.lower()]
+    return events
+
+
+def _norm_unit(unit: str) -> str:
+    """Normalize a unit for substance inference, collapsing simple plurals
+    (e.g. unit/units) so singular and plural share an inference key."""
+    unit = unit.lower()
+    if len(unit) > 1 and unit.isalpha() and unit.endswith("s"):
+        unit = unit[:-1]
+    return unit
+
+
+def _clear_winner(counter: Counter, min_observations: int = 3) -> str | None:
+    """Return the dominant key if it's a clear winner, else None.
+
+    A clear winner needs at least `min_observations` occurrences, a majority
+    share, and at least 2x the runner-up. Otherwise we'd rather not guess.
+    """
+    if not counter:
+        return None
+    ranked = counter.most_common(2)
+    top, top_n = ranked[0]
+    if top_n < min_observations or top_n / sum(counter.values()) < 0.5:
+        return None
+    if len(ranked) > 1 and top_n < 2 * ranked[1][1]:
+        return None
+    return top
+
+
+def _infer_implicit_substances(events: list[Event]) -> list[Event]:
+    """Fill in implicit substances for unit-only entries (an amount + unit with
+    no named substance).
+
+    The substance is inferred from the most common substance recorded with that
+    unit (and ROA, when the entry specifies one). Inference only happens when
+    there's a clear winner; otherwise the entry is left unresolved and a warning
+    is logged. When a substance is inferred, the dominant ROA for that unit+substance
+    is also filled in if the entry didn't specify one.
+    """
+    # Build frequency maps from entries that have an explicit substance + unit.
+    by_unit: dict[str, Counter] = defaultdict(Counter)
+    by_unit_roa: dict[tuple[str, str], Counter] = defaultdict(Counter)
+    roa_by_unit_sub: dict[tuple[str, str], Counter] = defaultdict(Counter)
+    for e in events:
+        if e.type != "dose" or not e.substance:
+            continue
+        unit = e.data.get("dose", {}).get("unit")
+        if not unit or unit == "unknown":
+            continue
+        unit = _norm_unit(unit)
+        by_unit[unit][e.substance] += 1
+        roa = e.data["dose"].get("roa")
+        if roa:
+            by_unit_roa[(unit, roa)][e.substance] += 1
+            roa_by_unit_sub[(unit, e.substance)][roa] += 1
+
+    n_inferred = 0
+    unresolved: Counter = Counter()
+    for e in events:
+        if e.type != "dose" or e.substance:
+            continue
+        dose = e.data.get("dose", {})
+        unit = dose.get("unit")
+        if not unit or unit == "unknown":
+            continue
+        unit = _norm_unit(unit)
+        roa = dose.get("roa")
+
+        winner = None
+        if roa and (unit, roa) in by_unit_roa:
+            winner = _clear_winner(by_unit_roa[(unit, roa)])
+        if winner is None:
+            winner = _clear_winner(by_unit[unit])
+        if winner is None:
+            unresolved[unit] += 1
+            continue
+
+        e.data["substance"] = winner
+        e.data["implicit_substance"] = True
+        if not roa:
+            roa_winner = _clear_winner(roa_by_unit_sub[(unit, winner)])
+            if roa_winner:
+                dose["roa"] = roa_winner
+        n_inferred += 1
+
+    if n_inferred:
+        logger.info(f"Inferred substance for {n_inferred} unit-only dose entries")
+    for unit, n in unresolved.most_common():
+        logger.warning(
+            f"Could not infer substance for {n} unit-only entries with unit '{unit}' "
+            "(no clear winner)"
+        )
     return events
 
 

--- a/qslang/load.py
+++ b/qslang/load.py
@@ -323,13 +323,16 @@ def _extend_substance_abbrs(events) -> list[Event]:
     return events
 
 
+# Units whose plural form should share an inference key with the singular,
+# so e.g. "1 serving" and "2 servings" land in the same bucket. An explicit
+# allowlist avoids mangling units that legitimately end in 's'.
+_UNIT_PLURALS = {"cups": "cup", "servings": "serving", "puffs": "puff", "hits": "hit"}
+
+
 def _norm_unit(unit: str) -> str:
-    """Normalize a unit for substance inference, collapsing simple plurals
-    (e.g. unit/units) so singular and plural share an inference key."""
+    """Map a unit to its inference key, collapsing known plurals onto the singular."""
     unit = unit.lower()
-    if len(unit) > 1 and unit.isalpha() and unit.endswith("s"):
-        unit = unit[:-1]
-    return unit
+    return _UNIT_PLURALS.get(unit, unit)
 
 
 def _clear_winner(counter: Counter, min_observations: int = 3) -> str | None:
@@ -355,9 +358,12 @@ def _infer_implicit_substances(events: list[Event]) -> list[Event]:
 
     The substance is inferred from the most common substance recorded with that
     unit (and ROA, when the entry specifies one). Inference only happens when
-    there's a clear winner; otherwise the entry is left unresolved and a warning
-    is logged. When a substance is inferred, the dominant ROA for that unit+substance
-    is also filled in if the entry didn't specify one.
+    there's a clear winner. When a substance is inferred, the dominant ROA for
+    that unit+substance is also filled in if the entry didn't specify one.
+
+    Entries that have no substance and for which none can be inferred are dropped
+    (with a warning): they carry no usable dose information and would otherwise
+    linger as ``substance=None`` "dose" events. Returns the filtered list.
     """
     # Build frequency maps from entries that have an explicit substance + unit.
     by_unit: dict[str, Counter] = defaultdict(Counter)
@@ -378,41 +384,49 @@ def _infer_implicit_substances(events: list[Event]) -> list[Event]:
 
     n_inferred = 0
     unresolved: Counter = Counter()
+    kept: list[Event] = []
     for e in events:
+        # Anything that isn't a substance-less dose passes through untouched.
         if e.type != "dose" or e.substance:
+            kept.append(e)
             continue
+
         dose = e.data.get("dose", {})
         unit = dose.get("unit")
-        if not unit or unit == "unknown":
-            continue
-        unit = _norm_unit(unit)
-        roa = dose.get("roa")
+        key = _norm_unit(unit) if unit and unit != "unknown" else None
 
         winner = None
-        if roa and (unit, roa) in by_unit_roa:
-            winner = _clear_winner(by_unit_roa[(unit, roa)])
-        if winner is None:
-            winner = _clear_winner(by_unit[unit])
-        if winner is None:
-            unresolved[unit] += 1
-            continue
+        if key is not None:
+            roa = dose.get("roa")
+            if roa and (key, roa) in by_unit_roa:
+                winner = _clear_winner(by_unit_roa[(key, roa)])
+            if winner is None:
+                winner = _clear_winner(by_unit[key])
 
+        if winner is None:
+            unresolved[unit or "unknown"] += 1
+            continue  # drop: no substance and none could be inferred
+
+        assert key is not None  # a winner implies a usable unit key
         e.data["substance"] = winner
         e.data["implicit_substance"] = True
-        if not roa:
-            roa_winner = _clear_winner(roa_by_unit_sub[(unit, winner)])
+        if not dose.get("roa"):
+            roa_winner = _clear_winner(roa_by_unit_sub[(key, winner)])
             if roa_winner:
                 dose["roa"] = roa_winner
         n_inferred += 1
+        kept.append(e)
 
     if n_inferred:
         logger.info(f"Inferred substance for {n_inferred} unit-only dose entries")
-    for unit, n in unresolved.most_common():
+    n_dropped = sum(unresolved.values())
+    if n_dropped:
+        breakdown = ", ".join(f"{n}x '{u}'" for u, n in unresolved.most_common())
         logger.warning(
-            f"Could not infer substance for {n} unit-only entries with unit '{unit}' "
-            "(no clear winner)"
+            f"Dropped {n_dropped} dose entries with no substance and no clear "
+            f"inference ({breakdown})"
         )
-    return events
+    return kept
 
 
 def test_load_events():

--- a/qslang/parsimonious.py
+++ b/qslang/parsimonious.py
@@ -60,22 +60,23 @@ grammar = parsimonious.Grammar(
     ws          = ~"[ ]*"
     nl          = ~"\n+"
 
-    dose        = patient? ws amount ws substance ws extra? ws roa?
+    dose        = patient? ws amount ws substance? ws extra? ws roa?
     dose_list   = dose (ws "+" ws dose)*
     patient     = "{" ~"[a-z]+"i "}"
     amount      = (unknown ws unit?) / (approx? fraction ws unit?) / (approx? number ws unit?)
     number      = ~"[0-9]+[.]?[0-9]*"
     unit        = prefixlessunit / (siprefix? baseunit)
-    prefixlessunit = "cup" / "x" / "IU" / "GDU" / "B" / "serving" / ~"puff(s)?"
+    prefixlessunit = "cup" / "x" / "IU" / "GDU" / "B" / "serving" / ~"puffs?" / ~"hits?"
     siprefix    = "n" / "u" / "mc" / "m" / "c" / "d"
     baseunit    = "g" / "l"
     substance   = ~"[a-z0-9\-äåö]+"i (ws !roa ~"[a-z0-9\-åäö]+"i)*
     extra       = "(" extra_data (ws "," ws extra_data)* ")"
-    extra_data  = percent / dose_list / short_note
+    extra_data  = percent / ratio_note / dose_list / short_note
+    ratio_note  = ratio (ws ~"[^,)+\n]+"i)?
     short_note  = ratio? ws ~"[A-Z][^,)\n]+"i?
     ratio       = ~"[0-9]+:[0-9]+"
     fraction    = ~"[0-9]+\/[0-9]+"
-    percent     = ~"[>]"? number "%" ws substance?
+    percent     = approx? ~"[>]"? number "%" ws substance?
     roa         = "oral" / ~"vap(ed|orized)?" / "intranasal" / ~"insuff(lated)?" / ~"subcut(aneous)?" / ~"subl(ingual)?" / "smoked" / "spliff" / "inhaled" / "buccal" / "rectal"
 
     approx = "~"
@@ -259,7 +260,12 @@ class Visitor(NodeVisitor):
         patient, _, dose, _, substance, a1, extras, a2, roa = visited_children
         assert a1 is None
         assert a2 is None
-        d = {
+        # `substance` is optional in the grammar: an entry can be just an amount
+        # and a unit with no named substance, so it arrives as a list with 0 or 1
+        # elements. None means the substance is implicit and is inferred later
+        # from the unit (see load._infer_implicit_substances).
+        substance = substance[0] if substance else None
+        d: dict[str, Any] = {
             "substance": substance,
             "dose": {**dose},
             "subdoses": [],
@@ -308,6 +314,9 @@ class Visitor(NodeVisitor):
         return {"note": node.text}
 
     def visit_short_note(self, node, visited_children) -> dict:
+        return {"note": node.text}
+
+    def visit_ratio_note(self, node, visited_children) -> dict:
         return {"note": node.text}
 
     def visit_ratio(self, node, visited_children) -> str:

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1,0 +1,65 @@
+from datetime import datetime
+
+from qslang.event import Event
+from qslang.load import _infer_implicit_substances
+
+
+def _dose(substance, unit, roa=None, amount=1.0):
+    dose = {"amount": amount, "unit": unit}
+    if roa:
+        dose["roa"] = roa
+    return Event(
+        timestamp=datetime(2020, 1, 1, 12, 0),
+        type="dose",
+        data={"substance": substance, "dose": dose},
+    )
+
+
+def test_infer_substance_from_unit():
+    # A clear winner per unit: "blip" -> Alpha, "blop" -> Beta.
+    # Plurals collapse to the same key, so a bare "blip" matches "blips".
+    events = (
+        [_dose("Alpha", "blips", "oral") for _ in range(10)]
+        + [_dose("Beta", "blops", "buccal") for _ in range(10)]
+        + [_dose(None, "blip"), _dose(None, "blop")]
+    )
+    _infer_implicit_substances(events)
+
+    bare_blip = next(e for e in events if e.data["dose"]["unit"] == "blip")
+    bare_blop = next(e for e in events if e.data["dose"]["unit"] == "blop")
+    assert bare_blip.substance == "Alpha"
+    assert bare_blop.substance == "Beta"
+    # marked as inferred and the dominant ROA is filled in
+    assert bare_blip.data.get("implicit_substance") is True
+    assert bare_blip.roa == "oral"
+    assert bare_blop.roa == "buccal"
+
+
+def test_no_inference_without_clear_winner():
+    # Two substances equally common for the same unit -> ambiguous, leave unknown
+    events = (
+        [_dose("Alpha", "blob") for _ in range(5)]
+        + [_dose("Beta", "blob") for _ in range(5)]
+        + [_dose(None, "blob")]
+    )
+    _infer_implicit_substances(events)
+    bare = next(e for e in events if e.substance is None)
+    assert bare.substance is None
+    assert "implicit_substance" not in bare.data
+
+
+def test_no_inference_below_min_observations():
+    # Only one observation of the unit -> not enough evidence to infer
+    events = [_dose("Rare", "zzz"), _dose(None, "zzz")]
+    _infer_implicit_substances(events)
+    bare = next(e for e in events if e.substance is None)
+    assert bare.substance is None
+
+
+def test_explicit_substance_not_overwritten():
+    events = [_dose("Alpha", "blips") for _ in range(5)] + [_dose("Gamma", "blip")]
+    _infer_implicit_substances(events)
+    assert all(e.substance for e in events)
+    # the explicit entry is left untouched
+    gamma = next(e for e in events if e.substance == "Gamma")
+    assert "implicit_substance" not in gamma.data

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -16,50 +16,51 @@ def _dose(substance, unit, roa=None, amount=1.0):
 
 
 def test_infer_substance_from_unit():
-    # A clear winner per unit: "blip" -> Alpha, "blop" -> Beta.
-    # Plurals collapse to the same key, so a bare "blip" matches "blips".
+    # A clear winner per unit: "serving(s)" -> Alpha, "cup(s)" -> Beta.
+    # Known plurals collapse to the singular, so a bare "serving" matches "servings".
     events = (
-        [_dose("Alpha", "blips", "oral") for _ in range(10)]
-        + [_dose("Beta", "blops", "buccal") for _ in range(10)]
-        + [_dose(None, "blip"), _dose(None, "blop")]
+        [_dose("Alpha", "servings", "oral") for _ in range(10)]
+        + [_dose("Beta", "cups", "buccal") for _ in range(10)]
+        + [_dose(None, "serving"), _dose(None, "cup")]
     )
-    _infer_implicit_substances(events)
+    result = _infer_implicit_substances(events)
 
-    bare_blip = next(e for e in events if e.data["dose"]["unit"] == "blip")
-    bare_blop = next(e for e in events if e.data["dose"]["unit"] == "blop")
-    assert bare_blip.substance == "Alpha"
-    assert bare_blop.substance == "Beta"
+    bare_serving = next(e for e in result if e.data["dose"]["unit"] == "serving")
+    bare_cup = next(e for e in result if e.data["dose"]["unit"] == "cup")
+    assert bare_serving.substance == "Alpha"
+    assert bare_cup.substance == "Beta"
     # marked as inferred and the dominant ROA is filled in
-    assert bare_blip.data.get("implicit_substance") is True
-    assert bare_blip.roa == "oral"
-    assert bare_blop.roa == "buccal"
+    assert bare_serving.data.get("implicit_substance") is True
+    assert bare_serving.roa == "oral"
+    assert bare_cup.roa == "buccal"
 
 
-def test_no_inference_without_clear_winner():
-    # Two substances equally common for the same unit -> ambiguous, leave unknown
+def test_drop_when_no_clear_winner():
+    # Two substances equally common for the same unit -> ambiguous, so the
+    # substance-less entry is dropped rather than kept with substance=None.
     events = (
         [_dose("Alpha", "blob") for _ in range(5)]
         + [_dose("Beta", "blob") for _ in range(5)]
         + [_dose(None, "blob")]
     )
-    _infer_implicit_substances(events)
-    bare = next(e for e in events if e.substance is None)
-    assert bare.substance is None
-    assert "implicit_substance" not in bare.data
+    result = _infer_implicit_substances(events)
+    assert len(result) == 10
+    assert all(e.substance for e in result)
 
 
-def test_no_inference_below_min_observations():
-    # Only one observation of the unit -> not enough evidence to infer
+def test_drop_below_min_observations():
+    # Only one observation of the unit -> not enough evidence; entry dropped
     events = [_dose("Rare", "zzz"), _dose(None, "zzz")]
-    _infer_implicit_substances(events)
-    bare = next(e for e in events if e.substance is None)
-    assert bare.substance is None
+    result = _infer_implicit_substances(events)
+    assert len(result) == 1
+    assert result[0].substance == "Rare"
 
 
 def test_explicit_substance_not_overwritten():
-    events = [_dose("Alpha", "blips") for _ in range(5)] + [_dose("Gamma", "blip")]
-    _infer_implicit_substances(events)
-    assert all(e.substance for e in events)
+    events = [_dose("Alpha", "servings") for _ in range(5)] + [_dose("Gamma", "serving")]
+    result = _infer_implicit_substances(events)
+    assert len(result) == 6
+    assert all(e.substance for e in result)
     # the explicit entry is left untouched
-    gamma = next(e for e in events if e.substance == "Gamma")
+    gamma = next(e for e in result if e.substance == "Gamma")
     assert "implicit_substance" not in gamma.data

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -104,6 +104,34 @@ def test_parse_event():
     print(parse(s))
 
 
+def test_parse_unit_only():
+    # An amount + unit with no named substance parses as a dose with substance=None
+    # (the substance is inferred later, see load._infer_implicit_substances)
+    parsed = parse("14:00 - 1 serving")
+    assert len(parsed) == 1
+    assert parsed[0].type == "dose"
+    assert parsed[0].substance is None
+    assert parsed[0].data["dose"] == {"amount": 1, "unit": "serving"}
+
+
+def test_parse_unit_only_approx():
+    parsed = parse("19:00 - ~2x")
+    assert len(parsed) == 1
+    assert parsed[0].type == "dose"
+    assert parsed[0].substance is None
+    assert parsed[0].data["dose"]["unit"] == "x"
+    assert parsed[0].data["dose"]["amount"] == 2
+    assert parsed[0].data["dose"]["approx"] is True
+
+
+def test_parse_percent_approx():
+    # An approximate percentage note inside parens (e.g. "~5%") should parse
+    parsed = parse("19:00 - 4cl Drink (~5%)")
+    assert len(parsed) == 1
+    assert parsed[0].substance == "Drink"
+    assert parsed[0].data["notes"] == [{"note": "~5%"}]
+
+
 def test_parse_alcohol():
     s = "# 2020-01-01\n18:30 - 4cl Gin (Tanqueray, 47%)"
     parsed = parse(s)


### PR DESCRIPTION
## Summary

Entries that give only an amount and a unit with **no named substance** were
being mishandled by the parser: depending on whether the unit was already in
the grammar, they were either **dropped as parse errors** or **mis-parsed with
the unit itself as the substance**. On real logs this silently lost or
mislabeled a large fraction of such entries.

This PR makes the substance optional and infers it from context:

- **Grammar:** a dose may now be just an amount + unit, with no substance.
- **Inference (`load._infer_implicit_substances`):** for a unit-only entry, the
  substance is inferred from the **most common substance recorded with that
  unit** (and ROA, when the entry specifies one). Inference only happens when
  there is a **clear winner** (≥3 observations, a majority share, and ≥2× the
  runner-up); otherwise the entry is left unresolved and a warning is logged.
  When a substance is inferred, the dominant ROA for that unit+substance is
  filled in if the entry didn't specify one. Inferred entries are flagged with
  `implicit_substance: True`.

### Related parser fixes surfaced by this change
- Treat `hit`/`hits` as units (matching the existing dose-unit definitions in
  `dose.py`), so they're no longer parsed as a substance.
- Accept approximate percentages in notes, e.g. `(~5%)`.
- Recognize ratio notes like `(10:1)` before attempting to parse a dose, so the
  now-optional substance doesn't turn them into phantom subdoses.

## Test plan
- [x] `pytest` — 53 passed (7 new: unit-only parsing, approx-percent note, and
  inference behavior incl. clear-winner / ambiguous / below-threshold /
  explicit-not-overwritten)
- [x] `mypy --ignore-missing-import --check-untyped-defs` — clean
- [x] Validated against real logs: parse-error rate dropped substantially and
  previously-mishandled unit-only entries are now recovered with inferred
  substances + ROAs